### PR TITLE
Update env_packager.bat quoting and prompts

### DIFF
--- a/env_packager.bat
+++ b/env_packager.bat
@@ -21,18 +21,19 @@ if not defined MM (
 rem 3) parse micromamba.bat if present
 if not defined MM (
     for /f "delims=" %%F in ('where micromamba.bat 2^>nul') do (
-        for /f "tokens=2 delims==\"" %%G in ('findstr /i "MAMBA_EXE" "%%F"') do if exist "%%G" set "MM=%%G"
-        for /f "tokens=2 delims==\"" %%H in ('findstr /i "MAMBA_ROOT_PREFIX" "%%F"') do set "MRP=%%H"
+        for /f "tokens=2 delims==^\"" %%G in ('findstr /i "MAMBA_EXE" "%%F"') do if exist "%%~G" set "MM=%%~G"
+        for /f "tokens=2 delims==^\"" %%H in ('findstr /i "MAMBA_ROOT_PREFIX" "%%F"') do set "MRP=%%~H"
         if defined MM goto :mm_found
     )
 )
 
-if not defined MM (
-    set /p MM=Enter full path to micromamba.exe:
-    if not exist "%MM%" (
-        echo File not found. Try again.
-        goto prompt_mm
-    )
+if not defined MM goto prompt_mm
+
+:prompt_mm
+set /p MM=Enter full path to micromamba.exe:
+if not exist "%MM%" (
+    echo File not found. Try again.
+    goto prompt_mm
 )
 :mm_found
 


### PR DESCRIPTION
## Summary
- fix `for /f` loops to properly parse `micromamba.bat`
- add `:prompt_mm` label and loop until valid micromamba path is provided

## Testing
- `wine cmd /c env_packager.bat 2>&1 | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_687fe6cc0ddc832faffd893f887d9dbe